### PR TITLE
Dynamic discover ethclients in k8s cluster

### DIFF
--- a/multiclient/client.go
+++ b/multiclient/client.go
@@ -81,6 +81,7 @@ func New(ctx context.Context, opts ...Option) (*Client, error) {
 		return nil, newErr
 	}
 
+	mc.retrydialWg.Add(1)
 	go mc.retrydial()
 
 	return mc, nil
@@ -762,7 +763,6 @@ func (mc *Client) DialClients(ctx context.Context) {
 }
 
 func (mc *Client) retrydial() {
-	mc.retrydialWg.Add(1)
 	defer mc.retrydialWg.Done()
 
 	ticker := time.NewTicker(retryPeriod)

--- a/multiclient/client.go
+++ b/multiclient/client.go
@@ -34,21 +34,26 @@ import (
 
 const (
 	dialTimeout = 5 * time.Second
+	retryPeriod = 10 * time.Second
 )
 
 var (
 	ErrInvalidTypeCast = errors.New("invalid type cast")
 	ErrNoEthClient     = errors.New("no eth client")
-
-	retryPeriod = 10 * time.Second
 )
 
 type Client struct {
+	ctx          context.Context
+	cancel       context.CancelFunc
 	rpcClientMap *Map
 }
 
 func New(ctx context.Context, opts ...Option) (*Client, error) {
+	// create client own context to control the internal go routines
+	myCtx, myCancel := context.WithCancel(context.Background())
 	mc := &Client{
+		ctx:          myCtx,
+		cancel:       myCancel,
 		rpcClientMap: NewMap(),
 	}
 	for _, opt := range opts {
@@ -57,45 +62,23 @@ func New(ctx context.Context, opts ...Option) (*Client, error) {
 		}
 	}
 
-	urls := mc.rpcClientMap.Keys()
-	lens := len(urls)
-	if lens == 0 {
+	// Dial each eth client
+	mc.DialClients(ctx)
+
+	// Return error if have no available eth client.
+	if len(mc.rpcClientMap.List()) == 0 {
 		return nil, ErrNoEthClient
 	}
 
-	log.Debug("Create multiclient", "urls", lens)
-	errCh := make(chan error, lens)
-	for _, rawURL := range urls {
-		go func(ctx context.Context, rawURL string) {
-			ctx, cancel := context.WithTimeout(ctx, dialTimeout)
-			defer cancel()
-			c, err := rpc.DialContext(ctx, rawURL)
-			if err == nil {
-				log.Info("Connect to ethclient successfully", "url", rawURL)
-				mc.rpcClientMap.Set(rawURL, c)
-			} else {
-				log.Error("Failed to dial eth client", "rawURL", rawURL, "err", err)
-			}
-			errCh <- err
-		}(ctx, rawURL)
-	}
+	go mc.retrydial()
 
-	var dialErr error
-	for i := 0; i < lens; i++ {
-		err := <-errCh
-		if err != nil {
-			dialErr = err
-		}
-	}
-	if dialErr != nil {
-		mc.Close()
-		return nil, dialErr
-	}
 	return mc, nil
 }
 
 // Close closes an existing RPC connection.
 func (mc *Client) Close() {
+	// stop go routines
+	mc.cancel()
 	clients := mc.rpcClientMap.List()
 	for _, c := range clients {
 		c.Close()
@@ -726,4 +709,48 @@ func postToAll(ctx context.Context, fns []postFn) error {
 		return nil
 	}
 	return lastError
+}
+
+type dialedClient struct {
+	url    string
+	client *rpc.Client
+}
+
+func (mc *Client) DialClients(ctx context.Context) {
+	urls := mc.rpcClientMap.NilClients()
+	dialCh := make(chan *dialedClient, len(urls))
+	for _, rawURL := range urls {
+		go func(rawURL string) {
+			dialCtx, cancel := context.WithTimeout(ctx, dialTimeout)
+			defer cancel()
+			c, err := rpc.DialContext(dialCtx, rawURL)
+			if err == nil {
+				log.Info("Connect to eth client successfully", "url", rawURL)
+			} else {
+				log.Warn("Failed to dial eth client", "url", rawURL, "err", err)
+			}
+			dialCh <- &dialedClient{url: rawURL, client: c}
+		}(rawURL)
+	}
+
+	for i := 0; i < len(urls); i++ {
+		dialed := <-dialCh
+		if dialed.client != nil {
+			mc.rpcClientMap.Replace(dialed.url, dialed.client)
+		}
+	}
+}
+
+func (mc *Client) retrydial() {
+	ticker := time.NewTicker(retryPeriod)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			mc.DialClients(mc.ctx)
+		case <-mc.ctx.Done():
+			// mc is closed, stop retry
+			return
+		}
+	}
 }

--- a/multiclient/consul.go
+++ b/multiclient/consul.go
@@ -1,0 +1,83 @@
+// Copyright 2018 AMIS Technologies
+// This file is part of the hypereth library.
+//
+// The hypereth library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The hypereth library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the hypereth library. If not, see <http://www.gnu.org/licenses/>.
+
+package multiclient
+
+import (
+	"fmt"
+	netURL "net/url"
+
+	"github.com/getamis/sirius/log"
+	consulAPI "github.com/hashicorp/consul/api"
+)
+
+// ConsulDiscovery discovers the dynamic ethclient endpoints through consul server.
+// TODO: should watch the change of endpoints
+func ConsulDiscovery(rawURL, serviceID, serviceScheme string) Option {
+	return func(mc *Client) error {
+		client, err := createConsulClient(rawURL)
+		if err != nil {
+			return err
+		}
+		urls, err := getEthURLsFromConsul(client, serviceID, serviceScheme)
+		if err != nil {
+			return err
+		}
+		log.Info("EthClients from consul", "urls", urls)
+		for _, url := range urls {
+			mc.rpcClientMap.Set(url, nil)
+		}
+		return nil
+	}
+}
+
+func getEthURLsFromConsul(client *consulAPI.Client, serviceID, serviceScheme string) ([]string, error) {
+	list, _, err := client.Catalog().Service(serviceID, "", nil)
+	if err != nil {
+		log.Error("Failed to get service from consul", "serviceID", serviceID, "err", err)
+		return nil, err
+	}
+
+	ethURLs := make([]string, len(list))
+	for i, srv := range list {
+		addr := srv.ServiceAddress
+		if addr == "" {
+			addr = srv.Address
+		}
+		ethURLs[i] = fmt.Sprintf("%s://%s:%d", serviceScheme, addr, srv.ServicePort)
+	}
+	return ethURLs, nil
+}
+
+func createConsulClient(rawURL string) (*consulAPI.Client, error) {
+	consulURL, err := netURL.Parse(rawURL)
+	if err != nil {
+		log.Error("Failed to parse consul url", "url", rawURL, "err", err)
+		return nil, err
+	}
+
+	config := &consulAPI.Config{
+		Address: consulURL.Host,
+		Scheme:  consulURL.Scheme,
+	}
+
+	client, err := consulAPI.NewClient(config)
+	if err != nil {
+		log.Error("Failed to create consul client", "err", err)
+		return nil, err
+	}
+	return client, nil
+}

--- a/multiclient/consul.go
+++ b/multiclient/consul.go
@@ -38,7 +38,7 @@ func ConsulDiscovery(rawURL, serviceID, serviceScheme string) Option {
 		}
 		log.Info("EthClients from consul", "urls", urls)
 		for _, url := range urls {
-			mc.rpcClientMap.Set(url, nil)
+			mc.ClientMap().Set(url, nil)
 		}
 		return nil
 	}

--- a/multiclient/k8s.go
+++ b/multiclient/k8s.go
@@ -1,0 +1,111 @@
+// Copyright 2018 AMIS Technologies
+// This file is part of the hypereth library.
+//
+// The hypereth library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The hypereth library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the hypereth library. If not, see <http://www.gnu.org/licenses/>.
+
+package multiclient
+
+import (
+	"fmt"
+
+	"github.com/getamis/sirius/log"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+type KubeConfig struct {
+	// The file path to KUBE-CONFIG file
+	ConfigPath string
+	// The url to override the apiserver address in KUBE-CONFIG file
+	APIServer string
+}
+
+// K8sEndpointsDiscovery discovers the dynamic ethclient endpoints in k8s cluster.
+// There are two ways to access k8s cluster:
+// 1. `kubeconfig` is nil means will build in-cluster config with service account token assigned to k8s pod.
+// 2. `kubeconfig` is given means access k8s cluster with given apiserver address and KUBE-CONFIG file.
+// TODO: should watch the change of endpoints
+func K8sEndpointsDiscovery(namespace, service, scheme string, kubeconfig *KubeConfig) Option {
+	return func(mc *Client) error {
+		kubeClient, err := createKubeClient(kubeconfig)
+		if err != nil {
+			return err
+		}
+		urls, err := getEthURLsFromK8s(kubeClient, namespace, service, scheme)
+		if err != nil {
+			return err
+		}
+		log.Info("EthClients from k8s cluster", "urls", urls)
+		for _, url := range urls {
+			mc.rpcClientMap.Set(url, nil)
+		}
+		return nil
+	}
+}
+
+func getEthURLsFromK8s(kubeClient clientset.Interface, namespace, service, serviceScheme string) ([]string, error) {
+	e, err := kubeClient.CoreV1().Endpoints(namespace).Get(service, meta.GetOptions{})
+	if err != nil {
+		log.Error("Failed to get endpoints", "namespace", namespace, "name", service, "err", err)
+		return nil, err
+	}
+
+	ethURLs := make([]string, 0)
+	for _, s := range e.Subsets {
+		for _, addr := range s.Addresses {
+			for _, port := range s.Ports {
+				ethURLs = append(ethURLs, fmt.Sprintf("%s://%s:%d", serviceScheme, addr.IP, port.Port))
+			}
+		}
+	}
+	return ethURLs, nil
+}
+
+func createKubeClient(kubeconfig *KubeConfig) (clientset.Interface, error) {
+	var apiserver, configPath string
+	if kubeconfig != nil {
+		apiserver, configPath = kubeconfig.APIServer, kubeconfig.ConfigPath
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags(apiserver, configPath)
+	if err != nil {
+		log.Error("Failed to create k8s config", "apiserver", apiserver, "kubeconfig", kubeconfig, "err", err)
+		return nil, err
+	}
+
+	config.UserAgent = "hypereth/multiclient"
+	config.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
+	config.ContentType = "application/vnd.kubernetes.protobuf"
+
+	kubeClient, err := clientset.NewForConfig(config)
+	if err != nil {
+		log.Error("Failed to create k8s client", "err", err)
+		return nil, err
+	}
+
+	// Informers don't seem to do a good job logging error messages when it
+	// can't reach the server, making debugging hard. This makes it easier to
+	// figure out if apiserver is configured incorrectly.
+	log.Trace("Testing communication with k8s api server")
+	_, err = kubeClient.Discovery().ServerVersion()
+	if err != nil {
+		log.Error("Failed to communicate with k8s api server", "err", err)
+		return nil, err
+	}
+	log.Trace("Communication with k8s api server successful")
+
+	return kubeClient, nil
+}

--- a/multiclient/k8s.go
+++ b/multiclient/k8s.go
@@ -18,7 +18,6 @@ package multiclient
 
 import (
 	"fmt"
-	"sort"
 	"sync"
 
 	"github.com/getamis/sirius/log"
@@ -164,14 +163,14 @@ func (s *endpointStore) Update(obj interface{}) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	// Add news urls
+	// Add new urls
 	for _, url := range news {
 		if c := s.rpcClientMap.Get(url); c == nil {
 			s.rpcClientMap.Set(url, nil)
 		}
 	}
 
-	// Remove olds urls
+	// Remove old urls
 	olds := s.endpoints[o.GetUID()]
 	removed := findRemoved(olds, news)
 	for _, url := range removed {
@@ -260,9 +259,6 @@ func getEthURLsFromK8sEndpoint(e *v1.Endpoints, scheme string) []string {
 // findRemoved returns the string array represents the elements in olds array and removed
 // in news array.
 func findRemoved(olds, news []string) []string {
-	sort.Strings(olds)
-	sort.Strings(news)
-
 	removed := []string{}
 	for _, o := range olds {
 		find := false

--- a/multiclient/map.go
+++ b/multiclient/map.go
@@ -38,6 +38,9 @@ func (m *Map) Delete(key string) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
+	if c := m.m[key]; c != nil {
+		c.Close()
+	}
 	delete(m.m, key)
 }
 

--- a/multiclient/map.go
+++ b/multiclient/map.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/getamis/sirius/log"
 )
 
 type Map struct {
@@ -42,6 +43,7 @@ func (m *Map) Delete(key string) {
 		c.Close()
 	}
 	delete(m.m, key)
+	log.Trace("Eth client removed", "url", key)
 }
 
 func (m *Map) Set(key string, value *rpc.Client) {
@@ -49,6 +51,7 @@ func (m *Map) Set(key string, value *rpc.Client) {
 	defer m.lock.Unlock()
 
 	m.m[key] = value
+	log.Trace("Eth client added", "url", key)
 }
 
 func (m *Map) Replace(key string, value *rpc.Client) {

--- a/multiclient/map.go
+++ b/multiclient/map.go
@@ -48,6 +48,15 @@ func (m *Map) Set(key string, value *rpc.Client) {
 	m.m[key] = value
 }
 
+func (m *Map) Replace(key string, value *rpc.Client) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	if _, ok := m.m[key]; ok {
+		m.m[key] = value
+	}
+}
+
 func (m *Map) Get(key string) *rpc.Client {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
@@ -99,6 +108,19 @@ func (m *Map) Keys() []string {
 	for k := range m.m {
 		urls[index] = k
 		index++
+	}
+	return urls
+}
+
+func (m *Map) NilClients() []string {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
+	urls := make([]string, 0)
+	for k, v := range m.m {
+		if v == nil {
+			urls = append(urls, k)
+		}
 	}
 	return urls
 }

--- a/multiclient/option.go
+++ b/multiclient/option.go
@@ -28,7 +28,7 @@ func EthURLs(urls []string) Option {
 	return func(mc *Client) error {
 		log.Info("EthClients from static list", "urls", urls)
 		for _, url := range urls {
-			mc.rpcClientMap.Set(url, nil)
+			mc.ClientMap().Set(url, nil)
 		}
 		return nil
 	}

--- a/multiclient/option.go
+++ b/multiclient/option.go
@@ -17,169 +17,19 @@
 package multiclient
 
 import (
-	"fmt"
-	"net/url"
-
 	"github.com/getamis/sirius/log"
-	consulAPI "github.com/hashicorp/consul/api"
-	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clientset "k8s.io/client-go/kubernetes"
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 // Option represents a Client option
 type Option func(*Client) error
 
 // EthURLs represents static ethclient endpoints.
-func EthURLs(ethURLs []string) Option {
+func EthURLs(urls []string) Option {
 	return func(mc *Client) error {
-		log.Info("EthClients from static list", "urls", ethURLs)
-		for _, url := range ethURLs {
-			mc.rpcClientMap.Set(url, nil)
-		}
-		return nil
-	}
-}
-
-// ConsulDiscovery discovers the dynamic ethclient endpoints through consul server.
-// TODO: should watch the change of endpoints
-func ConsulDiscovery(rawURL, serviceID, serviceScheme string) Option {
-	return func(mc *Client) error {
-		client, err := createConsulClient(rawURL)
-		if err != nil {
-			return err
-		}
-		urls, err := getEthURLsFromConsul(client, serviceID, serviceScheme)
-		if err != nil {
-			return err
-		}
-		log.Info("EthClients from consul", "urls", urls)
+		log.Info("EthClients from static list", "urls", urls)
 		for _, url := range urls {
 			mc.rpcClientMap.Set(url, nil)
 		}
 		return nil
 	}
-}
-
-func getEthURLsFromConsul(client *consulAPI.Client, serviceID, serviceScheme string) ([]string, error) {
-	list, _, err := client.Catalog().Service(serviceID, "", nil)
-	if err != nil {
-		log.Error("Failed to get service from consul", "serviceID", serviceID, "err", err)
-		return nil, err
-	}
-
-	ethURLs := make([]string, len(list))
-	for i, srv := range list {
-		addr := srv.ServiceAddress
-		if addr == "" {
-			addr = srv.Address
-		}
-		ethURLs[i] = fmt.Sprintf("%s://%s:%d", serviceScheme, addr, srv.ServicePort)
-	}
-	return ethURLs, nil
-}
-
-func createConsulClient(rawURL string) (*consulAPI.Client, error) {
-	consulURL, err := url.Parse(rawURL)
-	if err != nil {
-		log.Error("Failed to parse consul url", "url", rawURL, "err", err)
-		return nil, err
-	}
-
-	config := &consulAPI.Config{
-		Address: consulURL.Host,
-		Scheme:  consulURL.Scheme,
-	}
-
-	client, err := consulAPI.NewClient(config)
-	if err != nil {
-		log.Error("Failed to create consul client", "err", err)
-		return nil, err
-	}
-	return client, nil
-}
-
-type KubeConfig struct {
-	// The file path to KUBE-CONFIG file
-	ConfigPath string
-	// The url to override the apiserver address in KUBE-CONFIG file
-	APIServer string
-}
-
-// K8sEndpointsDiscovery discovers the dynamic ethclient endpoints in k8s cluster.
-// There are two ways to access k8s cluster:
-// 1. `kubeconfig` is nil means will build in-cluster config with service account token assigned to k8s pod.
-// 2. `kubeconfig` is given means access k8s cluster with given apiserver address and KUBE-CONFIG file.
-// TODO: should watch the change of endpoints
-func K8sEndpointsDiscovery(namespace, service, scheme string, kubeconfig *KubeConfig) Option {
-	return func(mc *Client) error {
-		kubeClient, err := createKubeClient(kubeconfig)
-		if err != nil {
-			return err
-		}
-		urls, err := getEthURLsFromK8s(kubeClient, namespace, service, scheme)
-		if err != nil {
-			return err
-		}
-		log.Info("EthClients from k8s cluster", "urls", urls)
-		for _, url := range urls {
-			mc.rpcClientMap.Set(url, nil)
-		}
-		return nil
-	}
-}
-
-func getEthURLsFromK8s(kubeClient clientset.Interface, namespace, service, serviceScheme string) ([]string, error) {
-	e, err := kubeClient.CoreV1().Endpoints(namespace).Get(service, meta.GetOptions{})
-	if err != nil {
-		log.Error("Failed to get endpoints", "namespace", namespace, "name", service, "err", err)
-		return nil, err
-	}
-
-	ethURLs := make([]string, 0)
-	for _, s := range e.Subsets {
-		for _, addr := range s.Addresses {
-			for _, port := range s.Ports {
-				ethURLs = append(ethURLs, fmt.Sprintf("%s://%s:%d", serviceScheme, addr.IP, port.Port))
-			}
-		}
-	}
-	return ethURLs, nil
-}
-
-func createKubeClient(kubeconfig *KubeConfig) (clientset.Interface, error) {
-	var apiserver, configPath string
-	if kubeconfig != nil {
-		apiserver, configPath = kubeconfig.APIServer, kubeconfig.ConfigPath
-	}
-
-	config, err := clientcmd.BuildConfigFromFlags(apiserver, configPath)
-	if err != nil {
-		log.Error("Failed to create k8s config", "apiserver", apiserver, "kubeconfig", kubeconfig, "err", err)
-		return nil, err
-	}
-
-	config.UserAgent = "hypereth/multiclient"
-	config.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
-	config.ContentType = "application/vnd.kubernetes.protobuf"
-
-	kubeClient, err := clientset.NewForConfig(config)
-	if err != nil {
-		log.Error("Failed to create k8s client", "err", err)
-		return nil, err
-	}
-
-	// Informers don't seem to do a good job logging error messages when it
-	// can't reach the server, making debugging hard. This makes it easier to
-	// figure out if apiserver is configured incorrectly.
-	log.Trace("Testing communication with k8s api server")
-	_, err = kubeClient.Discovery().ServerVersion()
-	if err != nil {
-		log.Error("Failed to communicate with k8s api server", "err", err)
-		return nil, err
-	}
-	log.Trace("Communication with k8s api server successful")
-
-	return kubeClient, nil
 }


### PR DESCRIPTION
The first commit is refactor about dialing ethclients.
The second commit adds the k8s endpoint watch function to add new ethclients and removed unavailable ones.